### PR TITLE
Fix error details not being attached correctly

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -18,7 +18,7 @@ module.exports = ({ schema, options }) => {
 					'Event object failed validation',
 				)
 				handler.event.headers = Object.assign({}, handler.event.headers)
-				error.details = validationFailure.errors
+				error.details = validationFailure.details
 				throw error
 			}
 			return next()


### PR DESCRIPTION
Joi's validation failure object does not have an `errors` prop but has a `details` prop: https://github.com/sideway/joi/blob/master/API.md#validationerror